### PR TITLE
Refact: show rule errors

### DIFF
--- a/grails-app/controllers/com/mini/asaas/payer/PayerController.groovy
+++ b/grails-app/controllers/com/mini/asaas/payer/PayerController.groovy
@@ -5,6 +5,7 @@ import com.mini.asaas.customer.CustomerRepository
 import com.mini.asaas.enums.AlertType
 import grails.gorm.PagedResultList
 import grails.plugin.springsecurity.annotation.Secured
+import grails.validation.ValidationException
 
 class PayerController extends BaseController {
 
@@ -70,6 +71,9 @@ class PayerController extends BaseController {
             Payer payer = payerService.save(adapter)
             createFlash("Cadastro realizado!", AlertType.SUCCESS, true)
             redirect(action: "show", id: payer.id)
+        } catch (ValidationException validationException) {
+            createFlash(validationException.errors.allErrors.defaultMessage.join("; "), AlertType.ERROR, false)
+            render view: "create"
         } catch (Exception exception) {
             createFlash("Ocorreu um erro no cadastro!" + exception.getMessage(), AlertType.ERROR, false)
             render view: "create"
@@ -86,6 +90,9 @@ class PayerController extends BaseController {
             Payer payer = payerService.update(customerId, id, adapter)
             createFlash("Pagador atualizado com sucesso!", AlertType.SUCCESS, true)
             redirect(action: "show", id: payer.id)
+        } catch (ValidationException validationException) {
+            createFlash(validationException.errors.allErrors.defaultMessage.join("; "), AlertType.ERROR, false)
+            redirect(action: "show", id: params.id)
         } catch (Exception exception) {
             createFlash("Ocorreu um erro ao atualizar!" + exception.getMessage(), AlertType.ERROR, false)
             redirect(action: "show", id: params.id)

--- a/grails-app/controllers/com/mini/asaas/payer/PayerController.groovy
+++ b/grails-app/controllers/com/mini/asaas/payer/PayerController.groovy
@@ -91,10 +91,10 @@ class PayerController extends BaseController {
             createFlash("Pagador atualizado com sucesso!", AlertType.SUCCESS, true)
             redirect(action: "show", id: payer.id)
         } catch (BusinessException error) {
-            createFlash(error.getMessage(), AlertType.ERROR, false)
+            createFlash("Ocorreu um erro ao atualizar!" + error.getMessage(), AlertType.ERROR, false)
             redirect(action: "show", id: params.id)
-        } catch (Exception error) {
-            createFlash("Ocorreu um erro durante o cadastro.", AlertType.ERROR, false)
+        } catch (Exception exception) {
+            createFlash("Ocorreu um erro ao atualizar!" + exception.getMessage(), AlertType.ERROR, false)
             redirect(action: "show", id: params.id)
         }
     }

--- a/grails-app/controllers/com/mini/asaas/payer/PayerController.groovy
+++ b/grails-app/controllers/com/mini/asaas/payer/PayerController.groovy
@@ -3,7 +3,6 @@ package com.mini.asaas.payer
 import com.mini.asaas.BaseController
 import com.mini.asaas.customer.CustomerRepository
 import com.mini.asaas.enums.AlertType
-import com.mini.asaas.exceptions.BusinessException
 import grails.gorm.PagedResultList
 import grails.plugin.springsecurity.annotation.Secured
 
@@ -71,9 +70,6 @@ class PayerController extends BaseController {
             Payer payer = payerService.save(adapter)
             createFlash("Cadastro realizado!", AlertType.SUCCESS, true)
             redirect(action: "show", id: payer.id)
-        } catch (BusinessException exception) {
-            createFlash("Ocorreu um erro no cadastro!" + exception.getMessage(), AlertType.ERROR, false)
-            render view: "create"
         } catch (Exception exception) {
             createFlash("Ocorreu um erro no cadastro!" + exception.getMessage(), AlertType.ERROR, false)
             render view: "create"
@@ -90,9 +86,6 @@ class PayerController extends BaseController {
             Payer payer = payerService.update(customerId, id, adapter)
             createFlash("Pagador atualizado com sucesso!", AlertType.SUCCESS, true)
             redirect(action: "show", id: payer.id)
-        } catch (BusinessException error) {
-            createFlash("Ocorreu um erro ao atualizar!" + error.getMessage(), AlertType.ERROR, false)
-            redirect(action: "show", id: params.id)
         } catch (Exception exception) {
             createFlash("Ocorreu um erro ao atualizar!" + exception.getMessage(), AlertType.ERROR, false)
             redirect(action: "show", id: params.id)

--- a/grails-app/controllers/com/mini/asaas/payment/CreatePaymentController.groovy
+++ b/grails-app/controllers/com/mini/asaas/payment/CreatePaymentController.groovy
@@ -6,11 +6,11 @@ import com.mini.asaas.payer.Payer
 import com.mini.asaas.payer.PayerService
 import grails.plugin.springsecurity.annotation.Secured
 
-@Secured("permitAll")
 class CreatePaymentController extends BaseController{
 
     PayerService payerService
 
+    @Secured("permitAll")
     def index() {
         Long customerId = CustomerRepository.query([id: 1]).column("id").get()
 

--- a/grails-app/controllers/com/mini/asaas/payment/PaymentController.groovy
+++ b/grails-app/controllers/com/mini/asaas/payment/PaymentController.groovy
@@ -4,7 +4,6 @@ import com.mini.asaas.BaseController
 import com.mini.asaas.Payment.Payment
 import com.mini.asaas.customer.CustomerRepository
 import com.mini.asaas.enums.AlertType
-import com.mini.asaas.exceptions.BusinessException
 import grails.gorm.PagedResultList
 import grails.plugin.springsecurity.annotation.Secured
 
@@ -52,9 +51,6 @@ class PaymentController extends BaseController{
             Payment payment = paymentService.save(customerId, adapter)
             createFlash("Cadastro de pagamento realizado!", AlertType.SUCCESS, true)
             redirect(action: "show", id: payment.id)
-        } catch (BusinessException exception) {
-            createFlash("Ocorreu um erro no cadastro do pagamento! " + exception.getMessage(), AlertType.ERROR, false)
-            redirect(action: "create", params: params)
         } catch (Exception exception) {
             createFlash("Ocorreu um erro no cadastro!" + exception.getMessage(), AlertType.ERROR, false)
             redirect(action: "create", params: params)
@@ -69,9 +65,6 @@ class PaymentController extends BaseController{
             Payment payment = paymentService.update(customerId, adapter)
             createFlash("Pagamento atualizado com sucesso!", AlertType.SUCCESS, true)
             redirect(action: "show", id: payment.id)
-        } catch (BusinessException exception) {
-            createFlash("Ocorreu um erro ao atualizar pagamento! " + exception.getMessage(), AlertType.ERROR, false)
-            redirect(action: "show", id: params.id)
         } catch (Exception exception) {
             createFlash("Ocorreu um erro ao atualizar pagamento! " + exception.getMessage(), AlertType.ERROR, false)
             redirect(action: "show", id: params.id)
@@ -85,9 +78,6 @@ class PaymentController extends BaseController{
             Long customerId = CustomerRepository.query([id: 1]).column("id").get()
             paymentService.delete(customerId, id)
             createFlash("Pagamento deletado com sucesso!", AlertType.SUCCESS, true)
-            redirect(action: "index")
-        } catch (BusinessException exception) {
-            createFlash("Ocorreu um erro ao deletar! " + exception.getMessage(), AlertType.ERROR, false)
             redirect(action: "index")
         } catch (Exception exception) {
             createFlash("Ocorreu um erro ao deletar! " + exception.getMessage(), AlertType.ERROR, false)
@@ -103,9 +93,6 @@ class PaymentController extends BaseController{
             paymentService.restore(customerId, id)
             createFlash("Pagamento restaurado com sucesso!", AlertType.SUCCESS, true)
             redirect(action: "index")
-        } catch (BusinessException exception) {
-            createFlash("Houve um erro! " + exception.getMessage(), AlertType.ERROR, false)
-            redirect(action: "index")
         } catch (Exception exception) {
             createFlash("Houve um erro! " + exception.getMessage(), AlertType.ERROR, false)
             redirect(action: "index")
@@ -118,9 +105,6 @@ class PaymentController extends BaseController{
 
         try {
             paymentService.receive(id)
-            redirect(action: "show", id: params.id)
-        } catch (BusinessException exception) {
-            createFlash("Houve um erro! " + exception.getMessage(), AlertType.ERROR, false)
             redirect(action: "show", id: params.id)
         } catch (Exception exception) {
             log.error(exception)

--- a/grails-app/controllers/com/mini/asaas/payment/PaymentController.groovy
+++ b/grails-app/controllers/com/mini/asaas/payment/PaymentController.groovy
@@ -14,8 +14,6 @@ class PaymentController extends BaseController{
 
     PaymentService paymentService
 
-    PayerService payerService
-
     @Secured("permitAll")
     def index() {
         List<String> statusFilterList = []

--- a/grails-app/controllers/com/mini/asaas/payment/PaymentController.groovy
+++ b/grails-app/controllers/com/mini/asaas/payment/PaymentController.groovy
@@ -55,7 +55,7 @@ class PaymentController extends BaseController{
             createFlash("Cadastro de pagamento realizado!", AlertType.SUCCESS, true)
             redirect(action: "show", id: payment.id)
         } catch (BusinessException exception) {
-            createFlash("Ocorreu um erro no cadastro do pagamento: " + exception.getMessage(), AlertType.ERROR, false)
+            createFlash("Ocorreu um erro no cadastro do pagamento! " + exception.getMessage(), AlertType.ERROR, false)
             redirect(action: "create", params: params)
         } catch (Exception exception) {
             createFlash("Ocorreu um erro no cadastro!" + exception.getMessage(), AlertType.ERROR, false)
@@ -72,10 +72,10 @@ class PaymentController extends BaseController{
             createFlash("Pagamento atualizado com sucesso!", AlertType.SUCCESS, true)
             redirect(action: "show", id: payment.id)
         } catch (BusinessException exception) {
-            createFlash("Ocorreu um erro ao atualizar pagamento: " + exception.getMessage(), AlertType.ERROR, false)
+            createFlash("Ocorreu um erro ao atualizar pagamento! " + exception.getMessage(), AlertType.ERROR, false)
             redirect(action: "show", id: params.id)
         } catch (Exception exception) {
-            createFlash("Ocorreu um erro ao atualizar pagamento: " + exception.getMessage(), AlertType.ERROR, false)
+            createFlash("Ocorreu um erro ao atualizar pagamento! " + exception.getMessage(), AlertType.ERROR, false)
             redirect(action: "show", id: params.id)
         }
     }
@@ -89,10 +89,10 @@ class PaymentController extends BaseController{
             createFlash("Pagamento deletado com sucesso!", AlertType.SUCCESS, true)
             redirect(action: "index")
         } catch (BusinessException exception) {
-            createFlash("Ocorreu um erro ao deletar: " + exception.getMessage(), AlertType.ERROR, false)
+            createFlash("Ocorreu um erro ao deletar! " + exception.getMessage(), AlertType.ERROR, false)
             redirect(action: "index")
         } catch (Exception exception) {
-            createFlash("Ocorreu um erro ao deletar: " + exception.getMessage(), AlertType.ERROR, false)
+            createFlash("Ocorreu um erro ao deletar! " + exception.getMessage(), AlertType.ERROR, false)
             redirect(action: "index")
         }
     }
@@ -106,10 +106,10 @@ class PaymentController extends BaseController{
             createFlash("Pagamento restaurado com sucesso!", AlertType.SUCCESS, true)
             redirect(action: "index")
         } catch (BusinessException exception) {
-            createFlash("Houve um erro: " + exception.getMessage(), AlertType.ERROR, false)
+            createFlash("Houve um erro! " + exception.getMessage(), AlertType.ERROR, false)
             redirect(action: "index")
         } catch (Exception exception) {
-            createFlash("Houve um erro: " + exception.getMessage(), AlertType.ERROR, false)
+            createFlash("Houve um erro! " + exception.getMessage(), AlertType.ERROR, false)
             redirect(action: "index")
         }
     }
@@ -122,11 +122,11 @@ class PaymentController extends BaseController{
             paymentService.receive(id)
             redirect(action: "show", id: params.id)
         } catch (BusinessException exception) {
-            createFlash("Houve um erro: " + exception.getMessage(), AlertType.ERROR, false)
+            createFlash("Houve um erro! " + exception.getMessage(), AlertType.ERROR, false)
             redirect(action: "show", id: params.id)
         } catch (Exception exception) {
             log.error(exception)
-            createFlash("Houve um erro: " + exception.getMessage(), AlertType.ERROR, false)
+            createFlash("Houve um erro! " + exception.getMessage(), AlertType.ERROR, false)
             redirect(action: "show", id: params.id)
         }
     }
@@ -140,7 +140,7 @@ class PaymentController extends BaseController{
             return [payment: payment]
         } catch (Exception exception) {
             log.error(exception)
-            createFlash("Houve um erro ao visualizar o comprovante: " + exception.getMessage(), AlertType.ERROR, false)
+            createFlash("Houve um erro ao visualizar o comprovante! " + exception.getMessage(), AlertType.ERROR, false)
             redirect(action: "show", id: id)
         }
     }

--- a/grails-app/controllers/com/mini/asaas/payment/PaymentController.groovy
+++ b/grails-app/controllers/com/mini/asaas/payment/PaymentController.groovy
@@ -6,6 +6,7 @@ import com.mini.asaas.customer.CustomerRepository
 import com.mini.asaas.enums.AlertType
 import grails.gorm.PagedResultList
 import grails.plugin.springsecurity.annotation.Secured
+import grails.validation.ValidationException
 
 class PaymentController extends BaseController{
 
@@ -51,9 +52,12 @@ class PaymentController extends BaseController{
             Payment payment = paymentService.save(customerId, adapter)
             createFlash("Cadastro de pagamento realizado!", AlertType.SUCCESS, true)
             redirect(action: "show", id: payment.id)
+        } catch (ValidationException validationException) {
+            createFlash(validationException.errors.allErrors.defaultMessage.join("; "), AlertType.ERROR, false)
+            redirect(controller: "createPayment", action: "index", params: params)
         } catch (Exception exception) {
             createFlash("Ocorreu um erro no cadastro!" + exception.getMessage(), AlertType.ERROR, false)
-            redirect(action: "create", params: params)
+            redirect(controller: "createPayment", action: "index", params: params)
         }
     }
 
@@ -65,6 +69,9 @@ class PaymentController extends BaseController{
             Payment payment = paymentService.update(customerId, adapter)
             createFlash("Pagamento atualizado com sucesso!", AlertType.SUCCESS, true)
             redirect(action: "show", id: payment.id)
+        } catch (ValidationException validationException) {
+            createFlash(validationException.errors.allErrors.defaultMessage.join("; "), AlertType.ERROR, false)
+            redirect(action: "show", id: params.id)
         } catch (Exception exception) {
             createFlash("Ocorreu um erro ao atualizar pagamento! " + exception.getMessage(), AlertType.ERROR, false)
             redirect(action: "show", id: params.id)

--- a/grails-app/services/com/mini/asaas/payer/PayerService.groovy
+++ b/grails-app/services/com/mini/asaas/payer/PayerService.groovy
@@ -86,21 +86,27 @@ class PayerService {
     private void validate(Long customerId, PayerAdapter adapter, Payer payer) {
         String searchedCpfCnpj = StringUtils.removeNonNumeric(adapter.cpfCnpj as String) ?: null
 
-        Payer existingWithCpfCnpj = PayerRepository.query([
+        Map<String, Object> queryCpfCnpj = [
                 customerId: customerId,
                 cpfCnpj: searchedCpfCnpj
-        ]).readOnly().get()
+        ] as Map<String, Object>
 
-        Payer existingWithEmail = PayerRepository.query([
-                customerId: customerId,
-                email: adapter.email
-        ]).readOnly().get()
+        if (payer.id) queryCpfCnpj."id[ne]" = payer.id
+        Boolean existingWithCpfCnpj = PayerRepository.query(queryCpfCnpj).exists()
 
-        if (existingWithCpfCnpj && existingWithCpfCnpj.id != payer.id) {
+        if (existingWithCpfCnpj) {
             DomainErrorUtils.addError(payer, "O cpf/cnpj informado já existe")
         }
 
-        if (existingWithEmail && existingWithEmail.id != payer.id) {
+        Map<String, Object> queryEmail = [
+                customerId: customerId,
+                email: adapter.email
+        ] as Map<String, Object>
+
+        if (payer.id) queryEmail."id[ne]" = payer.id
+        Boolean existingWithEmail = PayerRepository.query(queryEmail).exists()
+
+        if (existingWithEmail) {
             DomainErrorUtils.addError(payer, "O email informado já existe")
         }
 

--- a/grails-app/services/com/mini/asaas/payer/PayerService.groovy
+++ b/grails-app/services/com/mini/asaas/payer/PayerService.groovy
@@ -84,7 +84,6 @@ class PayerService {
     }
 
     private void validate(Long customerId, PayerAdapter adapter, Payer payer) {
-
         String searchedCpfCnpj = StringUtils.removeNonNumeric(adapter.cpfCnpj as String) ?: null
 
         Payer existingWithCpfCnpj = PayerRepository.query([
@@ -104,14 +103,6 @@ class PayerService {
         if (existingWithEmail && existingWithEmail.id != payer.id) {
             DomainErrorUtils.addError(payer, "O email informado já existe")
         }
-
-//        if (PayerRepository.query([customerId: customerId, cpfCnpj: searchedCpfCnpj]).readOnly().get()) {
-//            DomainErrorUtils.addError(payer, "O cpf/cnpj informado já existe")
-//        }
-
-//        if (PayerRepository.query([customerId: customerId, email: adapter.email]).readOnly().get()) {
-//            DomainErrorUtils.addError(payer, "O email informado já existe")
-//        }
 
         if (!adapter.name) DomainErrorUtils.addError(payer, "Campo nome vazio")
 

--- a/grails-app/services/com/mini/asaas/payer/PayerService.groovy
+++ b/grails-app/services/com/mini/asaas/payer/PayerService.groovy
@@ -15,12 +15,9 @@ import javax.xml.bind.ValidationException
 class PayerService {
 
     public Payer save(PayerAdapter adapter) {
-        println("Entrei para salvar")
         Payer payer = new Payer()
         Customer customer = Customer.get(1)
-        println("Vou validar")
         validate(customer.id, adapter, payer)
-        println("Validei")
 
         if (payer.hasErrors()) {
             List<String> errorMessages = payer.errors.allErrors.collect { it.defaultMessage }

--- a/grails-app/services/com/mini/asaas/payer/PayerService.groovy
+++ b/grails-app/services/com/mini/asaas/payer/PayerService.groovy
@@ -7,8 +7,7 @@ import com.mini.asaas.utils.EmailUtils
 import com.mini.asaas.utils.StringUtils
 import grails.compiler.GrailsCompileStatic
 import grails.gorm.transactions.Transactional
-
-import javax.xml.bind.ValidationException
+import grails.validation.ValidationException
 
 @Transactional
 @GrailsCompileStatic
@@ -20,8 +19,7 @@ class PayerService {
         validate(customer.id, adapter, payer)
 
         if (payer.hasErrors()) {
-            List<String> errorMessages = payer.errors.allErrors.collect { it.defaultMessage }
-            throw new ValidationException(" Falha ao cadastrar pagador: " + errorMessages.join("; "))
+            throw new ValidationException(" Falha ao cadastrar pagador: ", payer.errors)
         }
 
         buildPayer(adapter, payer)
@@ -45,8 +43,7 @@ class PayerService {
         validate(customerId, adapter, payer)
 
         if (payer.hasErrors()) {
-            List<String> errorMessages = payer.errors.allErrors.collect { it.defaultMessage }
-            throw new ValidationException(" Falha ao atualizar pagador: " + errorMessages.join("; "))
+            throw new ValidationException(" Falha ao atualizar pagador: ", payer.errors)
         }
 
         buildPayer(adapter, payer)

--- a/grails-app/services/com/mini/asaas/payment/PaymentService.groovy
+++ b/grails-app/services/com/mini/asaas/payment/PaymentService.groovy
@@ -25,7 +25,10 @@ class PaymentService {
 
         validate(adapter, payment)
 
-        if (payment.hasErrors()) throw new ValidationException("Falha ao salvar novo Pagamento", payment.errors as String)
+        if (payment.hasErrors()) {
+            List<String> errorMessages = payment.errors.allErrors.collect { it.defaultMessage }
+            throw new ValidationException(" Falha ao atualizar pagamento: " + errorMessages.join("; "))
+        }
 
         buildPayment(adapter, payment)
 
@@ -41,7 +44,10 @@ class PaymentService {
         if (!payment) throw new RuntimeException("Pagamento não encontrado")
         validateUpdate(adapter, payment)
 
-        if (payment.hasErrors()) throw new ValidationException("Falha ao atualizar o Pagador", payment.errors as String)
+        if (payment.hasErrors()) {
+            List<String> errorMessages = payment.errors.allErrors.collect { it.defaultMessage }
+            throw new ValidationException(" Falha ao atualizar pagamento: " + errorMessages.join("; "))
+        }
 
         payment.payer = Payer.get(adapter.payerId)
         payment.billingType = adapter.billingType

--- a/grails-app/services/com/mini/asaas/payment/PaymentService.groovy
+++ b/grails-app/services/com/mini/asaas/payment/PaymentService.groovy
@@ -28,7 +28,6 @@ class PaymentService {
         if (payment.hasErrors()) {
             throw new ValidationException(" Falha ao realizar operação no pagamento: ", payment.errors)
         }
-        println("Não pode mostrar aqui")
         buildPayment(adapter, payment)
 
         payment.customer = customer

--- a/grails-app/services/com/mini/asaas/payment/PaymentService.groovy
+++ b/grails-app/services/com/mini/asaas/payment/PaymentService.groovy
@@ -10,8 +10,8 @@ import com.mini.asaas.utils.DateFormatUtils
 import com.mini.asaas.utils.DomainErrorUtils
 import grails.compiler.GrailsCompileStatic
 import grails.gorm.transactions.Transactional
+import grails.validation.ValidationException
 
-import javax.xml.bind.ValidationException
 
 @Transactional
 @GrailsCompileStatic
@@ -26,10 +26,9 @@ class PaymentService {
         validate(adapter, payment)
 
         if (payment.hasErrors()) {
-            List<String> errorMessages = payment.errors.allErrors.collect { it.defaultMessage }
-            throw new ValidationException(" Falha ao atualizar pagamento: " + errorMessages.join("; "))
+            throw new ValidationException(" Falha ao realizar operação no pagamento: ", payment.errors)
         }
-
+        println("Não pode mostrar aqui")
         buildPayment(adapter, payment)
 
         payment.customer = customer
@@ -45,8 +44,7 @@ class PaymentService {
         validateUpdate(adapter, payment)
 
         if (payment.hasErrors()) {
-            List<String> errorMessages = payment.errors.allErrors.collect { it.defaultMessage }
-            throw new ValidationException(" Falha ao atualizar pagamento: " + errorMessages.join("; "))
+            throw new ValidationException(" Falha ao atualizar pagamento: ", payment.errors)
         }
 
         payment.payer = Payer.get(adapter.payerId)

--- a/grails-app/views/createPayment/index.gsp
+++ b/grails-app/views/createPayment/index.gsp
@@ -13,7 +13,11 @@
 
     <atlas-page-content slot="content" class="js-atlas-content">
         <g:if test="${flash.message}">
-            <atlas-alert type="${flash.status}" message="${flash.message}"></atlas-alert>
+            <atlas-alert
+                    type="${flash.success ? 'success' : 'error'}"
+                    message="${flash.message}"
+                    class="js-atlas-alert"
+            ></atlas-alert>
         </g:if>
 
         <atlas-form class="form" action="${createLink(controller: "payment", action: "save")}">
@@ -83,7 +87,7 @@
             <atlas-button submit="true" description="Finalizar"></atlas-button>
 
             <atlas-button theme="danger" description="Cancelar" icon="x"
-                          href="${createLink(controller: "payment", action: "create")}">
+                          href="${createLink(controller: "createPayment", action: "index")}">
             </atlas-button>
         </atlas-form>
     </atlas-page-content>

--- a/grails-app/views/payer/create.gsp
+++ b/grails-app/views/payer/create.gsp
@@ -19,7 +19,11 @@
 
 <body>
 <g:if test="${flash.message}">
-    <atlas-alert type="${flash.status}" message="${flash.message}"></atlas-alert>
+    <atlas-alert
+            type="${flash.success ? 'success' : 'error'}"
+            message="${flash.message}"
+            class="js-atlas-alert"
+    ></atlas-alert>
 </g:if>
 <g:if
         test="${flash.code == "alreadyExistsAndDeleted.cpfCnpj" || flash.code == "alreadyExistsAndDeleted.email"}">
@@ -46,11 +50,6 @@
                             value="${params.name}"
                             required>
                     </atlas-input>
-                    <g:hasErrors bean="${errors}" field="name">
-                        <span class="form--error">
-                            <g:renderErrors bean="${errors}" field="name" />
-                        </span>
-                    </g:hasErrors>
                 </atlas-col>
                 <atlas-col lg="6">
                     <atlas-masked-input
@@ -63,11 +62,6 @@
                             value="${params.email}"
                             required>
                     </atlas-masked-input>
-                    <g:hasErrors bean="${errors}" field="email">
-                        <span class="form--error">
-                            <g:renderErrors bean="${errors}" field="email" />
-                        </span>
-                    </g:hasErrors>
                 </atlas-col>
             </atlas-row>
 
@@ -82,11 +76,6 @@
                             value="${params.cpfCnpj}"
                             required>
                     </atlas-masked-input>
-                    <g:hasErrors bean="${errors}" field="cpfCnpj">
-                        <span class="form--error">
-                            <g:renderErrors bean="${errors}" field="cpfCnpj" />
-                        </span>
-                    </g:hasErrors>
                 </atlas-col>
                 <atlas-col lg="4">
                     <atlas-masked-input
@@ -98,11 +87,6 @@
                             value="${params.phoneNumber}"
                             required>
                     </atlas-masked-input>
-                    <g:hasErrors bean="${errors}" field="phoneNumber">
-                        <span class="form--error">
-                            <g:renderErrors bean="${errors}" field="phoneNumber" />
-                        </span>
-                    </g:hasErrors>
                 </atlas-col>
             </atlas-row>
 

--- a/grails-app/views/payer/show.gsp
+++ b/grails-app/views/payer/show.gsp
@@ -19,7 +19,11 @@
 
 <body>
 <g:if test="${flash.message}">
-    <atlas-alert type="${flash.status}" message="${flash.message}"></atlas-alert>
+    <atlas-alert
+            type="${flash.success ? 'success' : 'error'}"
+            message="${flash.message}"
+            class="js-atlas-alert"
+    ></atlas-alert>
 </g:if>
 <g:if test="${flash.code == "alreadyExistsAndView.cpfCnpj" || flash.code == "alreadyExistsAndView.email"}">
     <atlas-helper message="Visualizar pagador"

--- a/grails-app/views/payer/showDeleted.gsp
+++ b/grails-app/views/payer/showDeleted.gsp
@@ -17,6 +17,7 @@
                 <atlas-table-col>Nome</atlas-table-col>
                 <atlas-table-col>CPF/CNPJ</atlas-table-col>
                 <atlas-table-col>E-mail</atlas-table-col>
+                <atlas-table-col>Restaurar</atlas-table-col>
             </atlas-table-header>
 
             <atlas-table-body slot="body">

--- a/grails-app/views/payment/show.gsp
+++ b/grails-app/views/payment/show.gsp
@@ -11,7 +11,11 @@
 
 <body>
 <g:if test="${flash.message}">
-    <atlas-alert type="${flash.status}" message="${flash.message}"></atlas-alert>
+    <atlas-alert
+            type="${flash.success ? 'success' : 'error'}"
+            message="${flash.message}"
+            class="js-atlas-alert"
+    ></atlas-alert>
 </g:if>
 
 <atlas-form-panel header="Detalhes da cobrança" description="" submit-button-label=""

--- a/grails-app/views/payment/show.gsp
+++ b/grails-app/views/payment/show.gsp
@@ -38,7 +38,7 @@
         </atlas-button>
     </g:if>
 
-    <g:if test="${payment.deleted || payment.status == PaymentStatus.CANCELED || payment.status == PaymentStatus.OVERDUE}">
+    <g:if test="${payment.deleted || payment.status == PaymentStatus.CANCELED}">
         <atlas-button slot="actions" description="Restaurar" icon="refresh" theme="danger"
                       href="${createLink(controller: "payment", action: "restore", params: [id: payment.id])}">
         </atlas-button>

--- a/src/main/groovy/com/mini/asaas/payer/PayerRepository.groovy
+++ b/src/main/groovy/com/mini/asaas/payer/PayerRepository.groovy
@@ -1,6 +1,7 @@
 package com.mini.asaas.payer
 
 import com.mini.asaas.repository.Repository
+import com.mini.asaas.utils.Utils
 import grails.compiler.GrailsCompileStatic
 import org.grails.datastore.mapping.query.api.BuildableCriteria
 
@@ -22,6 +23,10 @@ class PayerRepository implements Repository<Payer, PayerRepository> {
                 eq("email", search.email)
             }
 
+            if (search.containsKey("id[ne]")) {
+                ne("id", Utils.toLong(search."id[ne]"))
+            }
+
         }
 
     }
@@ -36,7 +41,8 @@ class PayerRepository implements Repository<Payer, PayerRepository> {
         return [
                 "cpfCnpj",
                 "email",
-                "customerId"
+                "customerId",
+                "id[ne]"
         ]
     }
 }

--- a/src/main/groovy/com/mini/asaas/utils/Utils.groovy
+++ b/src/main/groovy/com/mini/asaas/utils/Utils.groovy
@@ -13,4 +13,14 @@ class Utils {
         }
         return cleanedParams
     }
+
+    public static Long toLong(value) {
+        try {
+            if (value instanceof Long) return value
+            if (value instanceof BigInteger) return Long.valueOf(value.toString())
+            return Long.valueOf(value as String)
+        } catch (Exception exception) {
+            return null
+        }
+    }
 }


### PR DESCRIPTION
PR destinado à refatoração no domínio dos erros

1. Ajusta as mensagens de erro que aparecem pro usuário
2. Adiciona uma validação para não poder cadastrar payers com cpfCnpj/email iguais
- IMPORTANTE: Adiciona a lógica de remover da consulta o próprio Payer para que ele encontre algum cpfCnpj/email na base, com exceção de seu próprio, caso o cliente esteja atualizando um Payer.
3. Mostra todos os erros presentes na requisição, separados por ";"
4. Ajusta a mensagem que aparece no front, fazendo aparecer somente uma, informando os erros